### PR TITLE
Refer to dependencies folder for all github.com/youtube/vitess/go dependencies

### DIFF
--- a/dependency/bson/bson_test.go
+++ b/dependency/bson/bson_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/bytes2"
+	"github.com/xwb1989/sqlparser/dependency/bytes2"
 )
 
 type alltypes struct {

--- a/dependency/bson/custom_test.go
+++ b/dependency/bson/custom_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/bytes2"
+	"github.com/xwb1989/sqlparser/dependency/bytes2"
 )
 
 const (

--- a/dependency/bson/marshal_test.go
+++ b/dependency/bson/marshal_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/bytes2"
+	"github.com/xwb1989/sqlparser/dependency/bytes2"
 )
 
 type String1 string


### PR DESCRIPTION
All the vitess dependencies were copied to the dependencies folder but not all the imports were changed. This change fixes that problem, so tests now run properly.