### PR TITLE
Minor change to allow the Tokenizer to accept a io.ByteReader

### DIFF
--- a/token.go
+++ b/token.go
@@ -7,6 +7,7 @@ package sqlparser
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/xwb1989/sqlparser/dependency/sqltypes"
@@ -17,7 +18,7 @@ const EOFCHAR = 0x100
 // Tokenizer is the struct used to generate SQL
 // tokens for the parser.
 type Tokenizer struct {
-	InStream      *strings.Reader
+	InStream      io.ByteReader
 	AllowComments bool
 	ForceEOF      bool
 	lastChar      uint16


### PR DESCRIPTION
This makes it possible to use the Tokenizer with other types of Readers, not just strings.